### PR TITLE
Add rules to nginx.conf to redirect all http requests to https.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -31,12 +31,20 @@ http {
     #
     # GEN3 configuration
     #
+    # Redirect all HTTP requests to HTTPS.
+    # Reference:
+    # https://linuxize.com/post/redirect-http-to-https-in-nginx/
     server {
         listen       80;
-        server_name  revproxy-service;
-        resolver 127.0.0.11;
+        server_name  _;
+        resolver     127.0.0.11;
+        # Using 307 to temporarily reidrect to HTTPS.
+        return       307 https://$host$request_uri; 
+    }
 
+    server {
         listen 443 ssl;
+        server_name revproxy-service;
 
         ssl_certificate /etc/nginx/ssl/nginx.crt;
         ssl_certificate_key /etc/nginx/ssl/nginx.key;


### PR DESCRIPTION
Successfully tested on following URL's:
- Root domain:
  - http://aced-training.compbio.ohsu.edu → https://aced-training.compbio.ohsu.edu 
- Domain with path present:
  - http://aced-training.compbio.ohsu.edu/identity → https://aced-training.compbio.ohsu.edu/identity

Happy to add or remove line as needed!