### PR TITLE
Add certbot container for SSL certificate creation and renewal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -281,6 +281,7 @@ services:
       - ./Secrets/TLS/service.key:/etc/nginx/ssl/nginx.key
       - certdata:/var/www/certbot/
       - certs:/etc/letsencrypt/
+      - ./Secrets/.well-known:/etc/nginx/.well-known
     ports:
       - "80:80"
       - "443:443"
@@ -301,15 +302,14 @@ services:
     image: certbot/certbot
     container_name: certbot
     volumes:
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
       - certdata:/var/www/certbot/
       - certs:/etc/letsencrypt/
     depends_on:
       - revproxy-service
       - portal-service
-    command: >
-      certonly --webroot --webroot-path=/var/www/certbot
-      --email aced-admin@ohsu.edu --agree-tos --no-eff-email 
-      -d development.aced-idp.org 
+    command: certonly --webroot --webroot-path=/var/www/certbot --email beckmanl@ohsu.edu --agree-tos --force-renewal --no-eff-email -d staging.aced-idp.org -d minio-default-staging.aced-idp.org  -d minio-ohsu-staging.aced-idp.org  -d minio-ucl-staging.aced-idp.org  -d minio-manchester-staging.aced-idp.org  -d minio-stanford-staging.aced-idp.org  -d minio-default-console-staging.aced-idp.org  -d minio-ohsu-console-staging.aced-idp.org  -d minio-ucl-console-staging.aced-idp.org  -d minio-manchester-console-staging.aced-idp.org   -d minio-stanford-console-staging.aced-idp.org
 #  tube-service:
 #    image: "quay.io/cdis/tube:2021.03"
 #    container_name: tube-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -279,6 +279,8 @@ services:
       - ./minio.conf.staging:/etc/nginx/minio.conf
       - ./Secrets/TLS/service.crt:/etc/nginx/ssl/nginx.crt
       - ./Secrets/TLS/service.key:/etc/nginx/ssl/nginx.key
+      - certdata:/var/www/certbot/
+      - certs:/etc/letsencrypt/
     ports:
       - "80:80"
       - "443:443"
@@ -295,6 +297,19 @@ services:
       - fence-service
       - portal-service
       - pidgin-service
+  certbot:
+    image: certbot/certbot
+    container_name: certbot
+    volumes:
+      - certdata:/var/www/certbot/
+      - certs:/etc/letsencrypt/
+    depends_on:
+      - revproxy-service
+      - portal-service
+    command: >
+      certonly --webroot --webroot-path=/var/www/certbot
+      --email aced-admin@ohsu.edu --agree-tos --no-eff-email 
+      -d development.aced-idp.org 
 #  tube-service:
 #    image: "quay.io/cdis/tube:2021.03"
 #    container_name: tube-service
@@ -348,3 +363,5 @@ networks:
 volumes:
   psqldata:
   esdata:
+  certdata:
+  certs:

--- a/minio.conf.staging
+++ b/minio.conf.staging
@@ -51,9 +51,8 @@
         resolver 127.0.0.11;
         listen 443 ssl;
 
-        ssl_certificate /etc/nginx/ssl/nginx.crt;
-        ssl_certificate_key /etc/nginx/ssl/nginx.key;
-
+        ssl_certificate /etc/letsencrypt/live/staging.aced-idp.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/staging.aced-idp.org/privkey.pem;
 
         # To allow special characters in headers
         ignore_invalid_headers off;
@@ -78,6 +77,9 @@
 
             proxy_pass http://minio-default;
         }
+         location /.well-known/acme-challenge/ {
+             root /var/www/certbot;
+         }
     }
     server {
         server_name  minio-ohsu-staging.aced-idp.org;
@@ -86,9 +88,8 @@
         resolver 127.0.0.11;
         listen 443 ssl;
 
-        ssl_certificate /etc/nginx/ssl/nginx.crt;
-        ssl_certificate_key /etc/nginx/ssl/nginx.key;
-
+        ssl_certificate /etc/letsencrypt/live/staging.aced-idp.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/staging.aced-idp.org/privkey.pem;
 
         # To allow special characters in headers
         ignore_invalid_headers off;
@@ -113,6 +114,9 @@
 
             proxy_pass http://minio-ohsu;
         }
+         location /.well-known/acme-challenge/ {
+             root /var/www/certbot;
+         }
     }
     server {
         server_name  minio-ucl-staging.aced-idp.org;
@@ -121,9 +125,8 @@
         resolver 127.0.0.11;
         listen 443 ssl;
 
-        ssl_certificate /etc/nginx/ssl/nginx.crt;
-        ssl_certificate_key /etc/nginx/ssl/nginx.key;
-
+        ssl_certificate /etc/letsencrypt/live/staging.aced-idp.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/staging.aced-idp.org/privkey.pem;
 
         # To allow special characters in headers
         ignore_invalid_headers off;
@@ -148,6 +151,9 @@
 
             proxy_pass http://minio-ucl;
         }
+         location /.well-known/acme-challenge/ {
+             root /var/www/certbot;
+         }
     }
     server {
         server_name  minio-manchester-staging.aced-idp.org;
@@ -156,9 +162,8 @@
         resolver 127.0.0.11;
         listen 443 ssl;
 
-        ssl_certificate /etc/nginx/ssl/nginx.crt;
-        ssl_certificate_key /etc/nginx/ssl/nginx.key;
-
+        ssl_certificate /etc/letsencrypt/live/staging.aced-idp.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/staging.aced-idp.org/privkey.pem;
 
         # To allow special characters in headers
         ignore_invalid_headers off;
@@ -183,6 +188,9 @@
 
             proxy_pass http://minio-manchester;
         }
+         location /.well-known/acme-challenge/ {
+             root /var/www/certbot;
+         }
     }
     server {
         server_name  minio-stanford-staging.aced-idp.org;
@@ -191,9 +199,8 @@
         resolver 127.0.0.11;
         listen 443 ssl;
 
-        ssl_certificate /etc/nginx/ssl/nginx.crt;
-        ssl_certificate_key /etc/nginx/ssl/nginx.key;
-
+        ssl_certificate /etc/letsencrypt/live/staging.aced-idp.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/staging.aced-idp.org/privkey.pem;
 
         # To allow special characters in headers
         ignore_invalid_headers off;
@@ -218,6 +225,9 @@
 
             proxy_pass http://minio-stanford;
         }
+         location /.well-known/acme-challenge/ {
+             root /var/www/certbot;
+         }
     }
 
     #
@@ -231,9 +241,8 @@
 
         listen 443 ssl;
 
-        ssl_certificate /etc/nginx/ssl/nginx.crt;
-        ssl_certificate_key /etc/nginx/ssl/nginx.key;
-
+        ssl_certificate /etc/letsencrypt/live/staging.aced-idp.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/staging.aced-idp.org/privkey.pem;
 
         # To allow special characters in headers
         ignore_invalid_headers off;
@@ -265,6 +274,9 @@
 
             proxy_pass http://minio-default-console;
         }
+         location /.well-known/acme-challenge/ {
+             root /var/www/certbot;
+         }
     }
     server {
         server_name  minio-ohsu-console-staging.aced-idp.org;
@@ -274,9 +286,8 @@
 
         listen 443 ssl;
 
-        ssl_certificate /etc/nginx/ssl/nginx.crt;
-        ssl_certificate_key /etc/nginx/ssl/nginx.key;
-
+        ssl_certificate /etc/letsencrypt/live/staging.aced-idp.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/staging.aced-idp.org/privkey.pem;
 
         # To allow special characters in headers
         ignore_invalid_headers off;
@@ -308,6 +319,9 @@
 
             proxy_pass http://minio-ohsu-console;
         }
+         location /.well-known/acme-challenge/ {
+             root /var/www/certbot;
+         }
     }
     server {
         server_name  minio-ucl-console-staging.aced-idp.org;
@@ -317,9 +331,8 @@
 
         listen 443 ssl;
 
-        ssl_certificate /etc/nginx/ssl/nginx.crt;
-        ssl_certificate_key /etc/nginx/ssl/nginx.key;
-
+        ssl_certificate /etc/letsencrypt/live/staging.aced-idp.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/staging.aced-idp.org/privkey.pem;
 
         # To allow special characters in headers
         ignore_invalid_headers off;
@@ -351,6 +364,9 @@
 
             proxy_pass http://minio-ucl-console;
         }
+         location /.well-known/acme-challenge/ {
+             root /var/www/certbot;
+         }
     }
     server {
         server_name  minio-manchester-console-staging.aced-idp.org;
@@ -360,9 +376,8 @@
 
         listen 443 ssl;
 
-        ssl_certificate /etc/nginx/ssl/nginx.crt;
-        ssl_certificate_key /etc/nginx/ssl/nginx.key;
-
+        ssl_certificate /etc/letsencrypt/live/staging.aced-idp.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/staging.aced-idp.org/privkey.pem;
 
         # To allow special characters in headers
         ignore_invalid_headers off;
@@ -394,6 +409,9 @@
 
             proxy_pass http://minio-manchester-console;
         }
+         location /.well-known/acme-challenge/ {
+             root /var/www/certbot;
+         }
     }
     server {
         server_name  minio-stanford-console-staging.aced-idp.org;
@@ -403,9 +421,8 @@
 
         listen 443 ssl;
 
-        ssl_certificate /etc/nginx/ssl/nginx.crt;
-        ssl_certificate_key /etc/nginx/ssl/nginx.key;
-
+        ssl_certificate /etc/letsencrypt/live/staging.aced-idp.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/staging.aced-idp.org/privkey.pem;
 
         # To allow special characters in headers
         ignore_invalid_headers off;
@@ -437,5 +454,8 @@
 
             proxy_pass http://minio-stanford-console;
         }
+         location /.well-known/acme-challenge/ {
+             root /var/www/certbot;
+         }
     }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -38,8 +38,13 @@ http {
 
         listen 443 ssl;
 
-        ssl_certificate /etc/nginx/ssl/nginx.crt;
-        ssl_certificate_key /etc/nginx/ssl/nginx.key;
+        # Original certificates
+        # ssl_certificate /etc/nginx/ssl/nginx.crt;
+        # ssl_certificate_key /etc/nginx/ssl/nginx.key;
+
+        # New Certbot certificates
+        ssl_certificate /etc/letsencrypt/live/staging.aced-idp.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/staging.aced-idp.org/privkey.pem;
 
         set $access_token "";
         set $csrf_check "ok-tokenauth";
@@ -282,6 +287,10 @@ http {
 
         location /lw-workspace/ {
             return 302 /lw-workspace/proxy;
+        }
+
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
         }
     }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -97,6 +97,10 @@ http {
             proxy_pass http://portal-service/;
         }
 
+	location /.well-known/ {
+            root /etc/nginx;
+        }
+
         location /user/ {
             proxy_pass http://fence-service/;
         }
@@ -289,9 +293,9 @@ http {
             return 302 /lw-workspace/proxy;
         }
 
-        location /.well-known/acme-challenge/ {
-            root /var/www/certbot;
-        }
+         location /.well-known/acme-challenge/ {
+             root /var/www/certbot;
+         }
     }
 
 


### PR DESCRIPTION
Creates SSL certificates for [staging.aced-idp.org](https://staging.aced-idp.org). Certificates last for 60 days and can be renewed 30 days after creation.

Related to issue #29 (Longterm Renewable Lets Encrypt Wildcard Certifcation)